### PR TITLE
Select redis default host & port when XC_REDIS_HOST is nil

### DIFF
--- a/xc/redis_pool.lua
+++ b/xc/redis_pool.lua
@@ -1,6 +1,8 @@
 local redis = require 'resty.redis'
 
 local function get_host_and_port(s)
+  if s == nil then return { } end
+
   local res = { }
   local i = 1
 


### PR DESCRIPTION
This PR solves a bug. The program crashes when `XC_REDIS_HOST` is nil.