### PR TITLE
Use correct capitalization for APIcast

### DIFF
--- a/Dockerfile-apicast
+++ b/Dockerfile-apicast
@@ -1,4 +1,4 @@
-# In the future, when Apicast provide a standard way to install modules this
+# In the future, when APIcast provide a standard way to install modules this
 # Dockerfile might not be needed.
 FROM quay.io/3scale/apicast:v2
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-   3scale XC for Apicast
+   3scale XC for APIcast
    Copyright (c) 2016 3scale Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## Description
 
-XC is a module for [Apicast](https://github.com/3scale/apicast), 3scale's API Gateway.
-Apicast performs one call to 3scale's backend for each request that it
+XC is a module for [APIcast](https://github.com/3scale/apicast), 3scale's API Gateway.
+APIcast performs one call to 3scale's backend for each request that it
 receives. The goal of XC is to reduce latency and increase throughput by
 significantly reducing the number of requests made to 3scale's backend. In order
 to achieve that, XC caches authorization statuses and reports.
@@ -76,12 +76,12 @@ For a more detailed explanation about how XC works, please check this [design do
 
 ## Deployment
 
-At the moment, deploying Apicast with XC is not as convenient as we would like.
+At the moment, deploying APIcast with XC is not as convenient as we would like.
 We are currently working on offering an easy way to deploy it on [Openshift](https://www.openshift.com).
 
-In the meanwhile, you can use Docker or deploy XC locally. Deploying Apicast
-with XC is very similar to deploying Apicast. The only difference is that XC
-needs two environment variables not required in Apicast:
+In the meanwhile, you can use Docker or deploy XC locally. Deploying APIcast
+with XC is very similar to deploying APIcast. The only difference is that XC
+needs two environment variables not required in APIcast:
 ```
 APICAST_MODULE=apicast_xc
 XC_REDIS_HOST=your_redis_host.com:6379
@@ -103,21 +103,21 @@ $ docker run --name apicast --rm -p 8080:8080 -e XC_REDIS_HOST=your_redis_host.c
 
 - Run `make apicast.xc` to install XC's dependencies.
 - Copy `apicast_xc.lua` and the `xc` directory of this repo into the `src`
-  directory of Apicast.
+  directory of APIcast.
 
-Apicast can then be executed like this:
+APIcast can then be executed like this:
 ```
 $ XC_REDIS_HOST=your_redis_host.com:6379 APICAST_MODULE=apicast_xc THREESCALE_CONFIG_FILE=config.json bin/apicast
 ```
 
-For a more detailed explanation about deploying Apicast and running it, please
+For a more detailed explanation about deploying APIcast and running it, please
 check its [GitHub repo](https://github.com/3scale/apicast).
 
 Remember that you'll also need [xcflushd](https://github.com/3scale/xcflushd) running.
 
 ## Trade-offs
 
-Compared to Apicast:
+Compared to APIcast:
 
 ### Pros
 - Considerably lower latencies and higher throughput.
@@ -126,7 +126,7 @@ Compared to Apicast:
 
 ### Cons
 - Needs two extra components to work: Redis and the flusher.
-- Going over the defined usage limits is easier. Apicast reports to 3scale
+- Going over the defined usage limits is easier. APIcast reports to 3scale
   every time it receives a request. Reports are asynchronous and that
   means that we can go over the limits for a brief window of time. On the other
   hand, XC reports every X minutes (configurable) to 3scale. The window of time
@@ -140,7 +140,7 @@ These are some of the current limitations. They will be fixed if there is a need
 - XC can only hit one application per request.
 - XC is not compatible with 3scale's request logs feature.
 - The timestamp of the reported transactions loses resolution. Transactions
-  are assigned a timestamp when they are reported to 3scale. With Apicast this
+  are assigned a timestamp when they are reported to 3scale. With APIcast this
   happens in every request. On the other hand, with XC this happens when the
   flusher sends the reports. This happens every X minutes (configurable).
 

--- a/apicast_xc.lua
+++ b/apicast_xc.lua
@@ -13,9 +13,9 @@ function _M.access()
     ngx.exit(403)
   end
 
-  -- ngx.var.secret_token is set in the access() method of the Apicast default
+  -- ngx.var.secret_token is set in the access() method of the APIcast default
   -- module. That means that if we do not set it here, it will never be set.
-  -- Hopefully, in the future, Apicast will set the secret token in a way
+  -- Hopefully, in the future, APIcast will set the secret token in a way
   -- so that 3rd party modules do not need have to.
   ngx.var.secret_token = service.secret_token
 
@@ -26,7 +26,7 @@ function _M.access()
   -- those cases differently.
 end
 
--- Override methods implemented in Apicast that are not needed in XC
+-- Override methods implemented in APIcast that are not needed in XC
 _M.header_filter = function() end
 _M.body_filter = function() end
 _M.post_action = function() end

--- a/apicast_xc.rockspec
+++ b/apicast_xc.rockspec
@@ -6,7 +6,7 @@ source = {
   branch = "master"
 }
 description = {
-  summary = "XC for Apicast",
+  summary = "XC for APIcast",
   detailed = [[
     This module caches calls to 3scale.
   ]],

--- a/doc/design.md
+++ b/doc/design.md
@@ -2,10 +2,10 @@
 
 ## Description
 
-XC is a module for [Apicast](https://github.com/3scale/apicast), 3scale's API
+XC is a module for [APIcast](https://github.com/3scale/apicast), 3scale's API
 Gateway.
 
-When Apicast receives a request, it performs an `authrep` call to 3scale's
+When APIcast receives a request, it performs an `authrep` call to 3scale's
 backend. This `authrep` call consists of:
 
 1. Checking whether the request is authorized. 3scale lets its users define
@@ -54,7 +54,7 @@ If you want to learn more about the 3scale platform, you can check the
 
 ## How does XC work
 
-XC uses two software components that are not needed when using vanilla Apicast:
+XC uses two software components that are not needed when using vanilla APIcast:
 
 - [Redis](https://redis.io/): in-memory database where authorizations and usage
   reports are cached.
@@ -67,7 +67,7 @@ XC uses two software components that are not needed when using vanilla Apicast:
     3. Retrieving an authorization status from 3scale backend when it is not
        cached.
 
-XC receives from Apicast all the information needed to authorize and report the
+XC receives from APIcast all the information needed to authorize and report the
 usage of an application. This includes: a service ID, credentials, and the
 metrics to be reported. The credentials received depend on the authorization
 mode used. XC supports three authentication modes from 3scale: app ID, app key,


### PR DESCRIPTION
The correct spelling is "APIcast"