### PR TITLE
Update link to APIcast base image in Dockerfile-apicast

### DIFF
--- a/Dockerfile-apicast
+++ b/Dockerfile-apicast
@@ -1,6 +1,6 @@
 # In the future, when APIcast provide a standard way to install modules this
 # Dockerfile might not be needed.
-FROM quay.io/3scale/apicast:v2
+FROM quay.io/3scale/apicast:master
 
 USER root
 


### PR DESCRIPTION
We need to use master because v2 was recently merged to master in APIcast.