### PR TITLE
Use apicast:v3.0.0-alpha2 as the base image in Dockerfile-apicast

### DIFF
--- a/Dockerfile-apicast
+++ b/Dockerfile-apicast
@@ -1,6 +1,6 @@
 # In the future, when APIcast provide a standard way to install modules this
 # Dockerfile might not be needed.
-FROM quay.io/3scale/apicast:master
+FROM quay.io/3scale/apicast:v3.0.0-alpha2
 
 USER root
 


### PR DESCRIPTION
We should not be using 'master' as the version of the base image. It's better to choose a version that we know for sure that works with XC. Unfortunately, there is not a 'final' version that contains all the changes that XC needs to function correctly. v3.0.0-alpha2 is the latest release and it works fine. Let's use it until v3.0.0 is released.