### PR TITLE
Include the app_key in report keys

### DIFF
--- a/spec/storage_key_spec.lua
+++ b/spec/storage_key_spec.lua
@@ -117,6 +117,26 @@ describe('storage_keys', function()
         assert.are.same(expected, actual)
       end)
     end)
+
+    it('includes all the credentials needed to identify a report', function()
+      -- These are all the credentials that we can find in a report key.
+      local all_report_creds = { ['access_token'] = 'an_access_token',
+                                 ['app_id'] = 'an_app_id',
+                                 ['app_key'] = 'an_app_key',
+                                 ['user_id'] = 'a_user_id',
+                                 ['user_key'] = 'a_user_key' }
+
+      local encoded_creds = {}
+      for key, value in pairs(all_report_creds) do
+        table.insert(encoded_creds, key .. ':' .. value)
+      end
+      table.sort(encoded_creds) -- Credentials appear sorted in the key
+      encoded_creds = table.concat(encoded_creds, ',')
+
+      local expected = 'report,' .. 'service_id:' .. service_id .. ',' .. encoded_creds
+      local actual = storage_keys.get_report_key(service_id, all_report_creds)
+      assert.are.same(expected, actual)
+    end)
   end)
 
   describe('get_pubsub_req_msg', function()

--- a/xc/storage_keys.lua
+++ b/xc/storage_keys.lua
@@ -10,7 +10,11 @@ local _M = { AUTH_REQUESTS_CHANNEL = 'xc_channel_auth_requests',
 
 local AUTH_RESPONSES_CHANNEL_PREFIX = 'xc_channel_auth_response:'
 
-local REPORT_CREDS_IN_KEY = { 'app_id', 'user_key', 'access_token', 'user_id' }
+local REPORT_CREDS_IN_KEY = { 'app_id',
+                              'user_key',
+                              'access_token',
+                              'user_id',
+                              'app_key' }
 
 -- Escapes ':' and ','.
 local function escape(string)
@@ -84,7 +88,7 @@ end
 -- keys. However, for reporting, we do not care about the referrer, because
 -- the app is still the same. That's why the referrer is not included in
 -- 'report' keys. The credentials that can be used for reporting are: 'app_id',
--- 'user_key', 'access_token', 'user_id'.
+-- 'user_key', 'access_token', 'user_id', 'app_key'.
 --
 -- Params:
 -- service_id: String. Service ID.


### PR DESCRIPTION
Closes #10 

If we do not include the app_key in the report key, the flusher will not be able to know which app keys it needs to renew the TTL for.
We were including other credentials already like app_id, user_key, access_token, etc. but we forgot about app_key.