### PR TITLE
Use apicast 3.0.0 beta3

### DIFF
--- a/Dockerfile-apicast
+++ b/Dockerfile-apicast
@@ -1,6 +1,6 @@
 # In the future, when APIcast provide a standard way to install modules this
 # Dockerfile might not be needed.
-FROM quay.io/3scale/apicast:v3.0.0-alpha2
+FROM quay.io/3scale/apicast:v3.0.0-beta3
 
 USER root
 
@@ -9,9 +9,6 @@ RUN yum install -y epel-release \
  && yum upgrade -y \
  && yum install -y lua-devel make gcc wget unzip epel-release luarocks \
  && yum clean all -y
-
-# If I do not run this, nginx gives an error while booting...
-RUN rm -rf /opt/app-root/src/logs
 
 USER default
 

--- a/apicast_xc.lua
+++ b/apicast_xc.lua
@@ -1,13 +1,17 @@
 local xc = require 'xc/xc'
+local utils = require 'xc/utils'
 
 local _M = require 'apicast'
 
 function _M.access()
   local request = ngx.var.request
   local service = ngx.ctx.service
+
   local credentials = service:extract_credentials(request)
+  local parsed_creds = utils.parse_apicast_creds(credentials)
+
   local usage = service:extract_usage(request)
-  local auth_status = xc.authrep(tostring(service.id), credentials, usage)
+  local auth_status = xc.authrep(tostring(service.id), parsed_creds, usage)
 
   if auth_status.auth ~= xc.auth.ok then
     ngx.exit(403)

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -1,0 +1,17 @@
+describe('utils', function()
+  local utils = require 'xc/utils'
+
+  describe('parse_apicast_creds', function()
+    it('returns a table with keys(3scale creds: app_id, app_key, etc.) and their values',
+      function()
+        local app_id = 'an_app_id'
+        local app_key = 'an_app_key'
+        local apicast_creds = { app_id, app_key,
+                                app_id = app_id, app_key = app_key }
+
+        assert.are.same({ app_id = app_id, app_key = app_key },
+                        utils.parse_apicast_creds(apicast_creds))
+      end)
+  end)
+
+end)

--- a/xc/utils.lua
+++ b/xc/utils.lua
@@ -1,0 +1,18 @@
+local _M = { }
+
+-- The Apicast method that extracts the credentials from a request returns a
+-- table that includes the credential values, and also key - values where the
+-- keys represent credentials. So for example, a table that contains both
+-- an app_id and an app_key looks like this:
+-- { 'my_app_id', 'my_app_key', app_id = 'my_app_id', app_key = 'my_app_key' }
+-- For XC, we are only interested in the key values, and that's what this
+-- method returns.
+function _M.parse_apicast_creds(creds)
+  for i = 1, #creds do
+    creds[i] = nil
+  end
+
+  return creds
+end
+
+return _M


### PR DESCRIPTION
This PR modifies the Dockerfile to use the latest version of Apicast (3.0.0-beta3) as the base image.

It also introduces some minor changes to adapt the code to the new interface of the Apicast method that extract the credentials from a request.