### PR TITLE
Use apicast-3.0.0 as the base image

### DIFF
--- a/Dockerfile-apicast
+++ b/Dockerfile-apicast
@@ -1,6 +1,6 @@
 # In the future, when APIcast provide a standard way to install modules this
 # Dockerfile might not be needed.
-FROM quay.io/3scale/apicast:v3.0.0-rc1
+FROM quay.io/3scale/apicast:v3.0.0
 
 USER root
 


### PR DESCRIPTION
There weren't any changes between `v3.0.0-rc1` and `v3.0.0`, so it's safe to upgrade.