### PR TITLE
Make redis pool params configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ APICAST_MODULE=apicast_xc
 XC_REDIS_HOST=your_redis_host.com:6379
 ```
 
+Optionally, you can also configure other options of the redis pool with these
+environment variables:
+- `REDIS_TIMEOUT` (in milliseconds)
+- `REDIS_KEEPALIVE` (in milliseconds)
+- `REDIS_CONN_POOL`(number of connections in the pool)
+
 ### Docker
 
 Build the image:

--- a/xc/redis_pool.lua
+++ b/xc/redis_pool.lua
@@ -21,8 +21,8 @@ local host, port = unpack(get_host_and_port(os.getenv("XC_REDIS_HOST")))
 local _M = {
   host      = host or 'localhost',
   port      = tonumber(port) or 6379,
-  timeout   = 3000,  -- 3 seconds
-  keepalive = 10000, -- milliseconds
+  timeout   = tonumber(os.getenv("REDIS_TIMEOUT")) or 3000,  -- 3 seconds
+  keepalive = tonumber(os.getenv("REDIS_KEEPALIVE")) or 10000, -- milliseconds
   poolsize  = tonumber(os.getenv("REDIS_CONN_POOL")) or 10000 -- # connections
 }
 

--- a/xc/redis_pool.lua
+++ b/xc/redis_pool.lua
@@ -23,7 +23,7 @@ local _M = {
   port      = tonumber(port) or 6379,
   timeout   = 3000,  -- 3 seconds
   keepalive = 10000, -- milliseconds
-  poolsize  = os.getenv("REDIS_CONN_POOL") or 10000 -- # connections
+  poolsize  = tonumber(os.getenv("REDIS_CONN_POOL")) or 10000 -- # connections
 }
 
 -- @return table with a redis connection from the pool


### PR DESCRIPTION
This PR makes timeout and keepalive configurable, so closes #23 
This PR also fixes a bug. The connection pool size, when set via ENV, was a string instead of a number.